### PR TITLE
Fix Home Assistant log warning that object_id has been depreciated

### DIFF
--- a/Net2HassMqtt.Tests/ComponentTests/Framework/MqttMessageMatching/MqttMessageMatcherBase.cs
+++ b/Net2HassMqtt.Tests/ComponentTests/Framework/MqttMessageMatching/MqttMessageMatcherBase.cs
@@ -49,6 +49,7 @@ public abstract class MqttMessageMatcherBase(
                                        "json_attributes_topic": "net2hassmqtt_test_start/{{{deviceId}}}/{{{nodeId}}}",
                                        "name": "{{{nodeName}}}",
                                        "object_id": "{{{deviceId}}}_{{{nodeId}}}",
+                                       "default_entity_id": "{{{domainName}}}.{{{deviceId}}}_{{{nodeId}}}",
                                        "state_topic": "net2hassmqtt_test_start/{{{deviceId}}}/{{{nodeId}}}",
                                        "unique_id": "{{{deviceId}}}_{{{nodeId}}}",
                                        "value_template": "{{ value_json.state }}"

--- a/Net2HassMqtt/Mqtt/HassDiscoveryClient.cs
+++ b/Net2HassMqtt/Mqtt/HassDiscoveryClient.cs
@@ -1,7 +1,8 @@
-﻿using System.Text.Json;
-using NoeticTools.Net2HassMqtt.Configuration;
+﻿using NoeticTools.Net2HassMqtt.Configuration;
 using NoeticTools.Net2HassMqtt.Mqtt.Payloads.Discovery;
 using NoeticTools.Net2HassMqtt.Mqtt.Topics;
+using System.Text.Json;
+using System.Xml;
 
 
 namespace NoeticTools.Net2HassMqtt.Mqtt;
@@ -32,7 +33,8 @@ internal sealed class HassDiscoveryClient(string mqttClientId, INet2HassMqttClie
     public async Task PublishEntityConfigAsync<T>(string objectId, IEntityConfig config, DeviceConfig device, T payload)
         where T : EntityConfigMqttJsonBase
     {
-        payload.ObjectId = objectId;
+        payload.ObjectId = objectId; // todo: HASS has depreciated use of object_id in favour of using default_entity_id. No longer used after 2026.4.
+        payload.DefaultEntityId = $"{config.MqttTopicComponent}.{objectId}";
 
         var topic = new TopicBuilder().WithBaseTopic(mqttClientId)
                                       .WithComponent(payload.MqttTopicComponent)

--- a/Net2HassMqtt/Mqtt/Payloads/Discovery/EntityConfigMqttJsonBase.cs
+++ b/Net2HassMqtt/Mqtt/Payloads/Discovery/EntityConfigMqttJsonBase.cs
@@ -18,6 +18,7 @@ public abstract class EntityConfigMqttJsonBase : IEntityConfigMqttJson
         var uniqueId = entityUniqueId.ToMqttTopicSnakeCase();
         UniqueId = uniqueId;
         ObjectId = uniqueId;
+        DefaultEntityId = $"{config.MqttTopicComponent}.{uniqueId}";
         Icon = config.Icon;
         Name = config.EntityFriendlyName;
         MqttTopicComponent = config.MqttTopicComponent;
@@ -64,6 +65,10 @@ public abstract class EntityConfigMqttJsonBase : IEntityConfigMqttJson
     /// </summary>
     /// <remarks>
     ///     <para>
+    ///         Home Assistant has deprecated object_id in favor of default_entity_id.
+    ///         It will cease to be used Home Assistant after 2024.6.
+    ///     </para>
+    ///     <para>
     ///         When the entity is created in Home Assistant this value is used to generate the entity's ID.
     ///         As a unique_id is also provided users can change the entity ID in Home Assistant.
     ///         Net2HassMqtt uses the same value for both object_id and unique_id.
@@ -77,7 +82,26 @@ public abstract class EntityConfigMqttJsonBase : IEntityConfigMqttJson
     ///     </para>
     /// </remarks>
     [JsonPropertyName("object_id")]
-    public string ObjectId { get; set; }
+    public string ObjectId { get; set; } // todo: HASS has depreciated use of object_id in favour of using default_entity_id. No longer used after 2026.4.
+
+    /// <summary>
+    ///     The entity ID seen in HASS when referencing this entity. Must be prefixed with the domain, e.g. sensor.foobar.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Use default_entity_id instead of name for automatic generation of the entity ID.
+    ///         For example, sensor.foobar. When used without a unique_id, the entity ID will update during restart or reload if the entity ID is available. If the entity ID already exists, the entity ID will be created with a number at the end. When used with a unique_id, the default_entity_id is only used when the entity is added for the first time. When set, this overrides a user-customized entity ID if the entity was deleted and added again.
+    ///     </para>
+    ///     <para>
+    ///         For more information see
+    ///         <a href="https://www.home-assistant.io/integrations/mqtt/#naming-of-mqtt-entities">
+    ///             Home Assistant Naming of Entities
+    ///         </a>
+    ///         .
+    ///     </para>
+    /// </remarks>
+    [JsonPropertyName("default_entity_id")]
+    public string DefaultEntityId { get; set; }
 
     /// <summary>
     ///     Required. Topic to subscribe to for sensor values.

--- a/Net2HassMqtt/Mqtt/Topics/TopicBuilder.cs
+++ b/Net2HassMqtt/Mqtt/Topics/TopicBuilder.cs
@@ -77,10 +77,10 @@ internal sealed class TopicBuilder
     public MqttTopic NodeId { get; private set; } = "";
 
     /// <summary>
-    ///     In a Home Assistant discovery topic this is the entities `unique_id` or `object_id`
+    ///     In a Home Assistant discovery topic this is the entity's `unique_id` or `object_id`
     ///     In state update and set command message topics to the Net2HassMqtt client it is the entity's node ID.
     /// </summary>
-    public MqttTopic ObjectId { get; private set; } = "";
+    public MqttTopic ObjectId { get; private set; } = ""; // todo: HASS has depreciated use of object_id in favour of using default_entity_id. No longer used after 2026.4.
 
     public TopicAction TopicAction { get; private set; } = TopicAction.None;
 
@@ -227,7 +227,7 @@ internal sealed class TopicBuilder
         return this;
     }
 
-    public TopicBuilder WithObjectId(string objectId)
+    public TopicBuilder WithObjectId(string objectId)  // todo: HASS has depreciated use of object_id in favour of using default_entity_id. No longer used after 2026.4.
     {
         if (ObjectId.IsValid)
         {


### PR DESCRIPTION
Fixed Home Assistant MQTT discovery object_id depreciated warning.

> [!WARNING]
> This may make Net2HassMqtt incompatible with HASS prior to 2025.10.
> Hence, this release as a breaking change for users using older HASS versions.

Warning message was:

> entity XXXX uses the deprecated option object_id to set the default entity id. Replace the "object_id": "XXXX" option with "default_entity_id": "XXXX" in your published discovery configuration to fix this issue, or contact the maintainer .... that published this config to fix this. This will stop working in Home Assistant Core 2026.4

Added `default_entity_id` to MQTT message. `object_id` remains and will be removed some time after the release of HASS 2026.4.

ref: #18